### PR TITLE
Feat/add accessibility menu

### DIFF
--- a/src/app/articles/[topic]/[slug]/page.tsx
+++ b/src/app/articles/[topic]/[slug]/page.tsx
@@ -17,6 +17,8 @@ import TableOfContent from '@/components/mdx/TableOfContent';
 import ArticleCard from '@/components/ui/ArticleCard';
 import FormattedDate from '@/components/ui/FormattedDate';
 import ShareButton from '@/components/ui/ShareButton';
+import ReadingSurface from '@/components/mdx/ReadingSurface';
+import AccessibilityMenu from '@/components/mdx/AccessibilityMenu';
 
 interface PageProps {
   params: Promise<{ topic: string; slug: string }>;
@@ -189,6 +191,7 @@ export default async function ArticlePage({ params }: PageProps) {
             <div className='lg:hidden'>
               <MobileTableOfContent headings={headings} />
             </div>
+            <AccessibilityMenu />
             <div className='border-t border-[#0066ff] space-y-2 max-w-[72ch] mx-auto lg:max-w-[initial]'>
               <strong className='font-heading font-extrabold text-lg underline'>
                 Share the Article
@@ -205,9 +208,9 @@ export default async function ArticlePage({ params }: PageProps) {
         <div
           className={`${maximumContentClassName} lg:flex items-start justify-between gap-8`}
         >
-          <div className='basis-[72ch] max-w-[72ch] mx-auto lg:mx-[initial]'>
+          <ReadingSurface className='basis-[72ch] max-w-[72ch] mx-auto lg:mx-[initial]'>
             <MDXRemote source={content} components={coreMdxComponents} />
-          </div>
+          </ReadingSurface>
           <aside
             className='basis-[290px] flex-shrink-0 pb-12 px-6 sticky top-[70px] hidden lg:block'
             aria-label='Table of contents'

--- a/src/app/case-studies/[slug]/page.tsx
+++ b/src/app/case-studies/[slug]/page.tsx
@@ -14,8 +14,8 @@ import FormattedDate from '@/components/ui/FormattedDate';
 import CTAButton from '@/components/ui/CTAButton';
 import MobileTableOfContent from '@/components/mdx/MobileTableOfContent';
 import ImageCarousel from '@/components/ui/ProjectImageCarousel';
-import SlidingSettingsPanel from '@/components/mdx/AccessibilityMenu';
 import ReadingSurface from '@/components/mdx/ReadingSurface';
+import AccessibilityMenu from '@/components/mdx/AccessibilityMenu';
 
 interface CaseStudyPageProps {
   params: Promise<{ slug: string }>;
@@ -244,7 +244,7 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
           <div className='lg:hidden'>
             <MobileTableOfContent headings={headings} />
           </div>
-          <SlidingSettingsPanel />
+          <AccessibilityMenu />
           <div className='border-t border-[#0066ff] space-y-2 max-w-[72ch] mx-auto lg:max-w-[initial]'>
             <strong className='font-heading font-extrabold text-lg underline'>
               Share the Study

--- a/src/app/case-studies/[slug]/page.tsx
+++ b/src/app/case-studies/[slug]/page.tsx
@@ -14,6 +14,8 @@ import FormattedDate from '@/components/ui/FormattedDate';
 import CTAButton from '@/components/ui/CTAButton';
 import MobileTableOfContent from '@/components/mdx/MobileTableOfContent';
 import ImageCarousel from '@/components/ui/ProjectImageCarousel';
+import SlidingSettingsPanel from '@/components/mdx/AccessibilityMenu';
+import ReadingSurface from '@/components/mdx/ReadingSurface';
 
 interface CaseStudyPageProps {
   params: Promise<{ slug: string }>;
@@ -242,6 +244,7 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
           <div className='lg:hidden'>
             <MobileTableOfContent headings={headings} />
           </div>
+          <SlidingSettingsPanel />
           <div className='border-t border-[#0066ff] space-y-2 max-w-[72ch] mx-auto lg:max-w-[initial]'>
             <strong className='font-heading font-extrabold text-lg underline'>
               Share the Study
@@ -258,9 +261,9 @@ export default async function CaseStudyPage({ params }: CaseStudyPageProps) {
       <div
         className={`${maximumContentClassName} lg:flex items-start justify-between gap-8`}
       >
-        <div className='basis-[72ch] max-w-[72ch] mx-auto lg:mx-[initial] text-justify'>
+        <ReadingSurface className='basis-[72ch] max-w-[72ch] mx-auto lg:mx-[initial] text-justify'>
           <MDXRemote source={content} components={coreMdxComponents} />
-        </div>
+        </ReadingSurface>
         <aside
           className='basis-[290px] flex-shrink-0 pb-12 px-6 sticky top-[70px] hidden lg:block'
           aria-label='Table of contents'

--- a/src/components/icons/glyphs/UniversalAccessIcon.tsx
+++ b/src/components/icons/glyphs/UniversalAccessIcon.tsx
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * SVG Code by:
+ * Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free
+ * Copyright 2025 Fonticons, Inc.
+ *
+ * For more information, check the LICENSE.txt of the Repository
+ */
+
+const iconVariants = {
+  solid: {
+    viewBox: '0 0 512 512',
+    path: 'M0 256a256 256 0 1 1 512 0A256 256 0 1 1 0 256zm161.5-86.1c-12.2-5.2-26.3 .4-31.5 12.6s.4 26.3 12.6 31.5l11.9 5.1c17.3 7.4 35.2 12.9 53.6 16.3l0 50.1c0 4.3-.7 8.6-2.1 12.6l-28.7 86.1c-4.2 12.6 2.6 26.2 15.2 30.4s26.2-2.6 30.4-15.2l24.4-73.2c1.3-3.8 4.8-6.4 8.8-6.4s7.6 2.6 8.8 6.4l24.4 73.2c4.2 12.6 17.8 19.4 30.4 15.2s19.4-17.8 15.2-30.4l-28.7-86.1c-1.4-4.1-2.1-8.3-2.1-12.6l0-50.1c18.4-3.5 36.3-8.9 53.6-16.3l11.9-5.1c12.2-5.2 17.8-19.3 12.6-31.5s-19.3-17.8-31.5-12.6L338.7 175c-26.1 11.2-54.2 17-82.7 17s-56.5-5.8-82.7-17l-11.9-5.1zM256 160a40 40 0 1 0 0-80 40 40 0 1 0 0 80z',
+  },
+};
+
+type IconVariant = keyof typeof iconVariants;
+
+interface IconProps {
+  width?: number | string;
+  height?: number | string;
+  className?: string;
+  color?: string;
+  variant?: IconVariant;
+}
+
+export default function UniversalAccessIcon({
+  width = 24,
+  height = 24,
+  className,
+  variant = 'solid',
+  color,
+}: IconProps) {
+  const selectedVariant = iconVariants[variant];
+
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox={selectedVariant.viewBox}
+      width={width}
+      height={height}
+      fill={color || 'currentColor'}
+      className={className}
+    >
+      <path d={selectedVariant.path} />
+    </svg>
+  );
+}

--- a/src/components/icons/ui/ListIcon.tsx
+++ b/src/components/icons/ui/ListIcon.tsx
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * SVG Code by:
+ * Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com
+ * License - https://fontawesome.com/license/free
+ * Copyright 2025 Fonticons, Inc.
+ *
+ * For more information, check the LICENSE.txt of the Repository
+ */
+
+const iconVariants = {
+  solid: {
+    viewBox: '0 0 512 512',
+    path: 'M40 48C26.7 48 16 58.7 16 72l0 48c0 13.3 10.7 24 24 24l48 0c13.3 0 24-10.7 24-24l0-48c0-13.3-10.7-24-24-24L40 48zM192 64c-17.7 0-32 14.3-32 32s14.3 32 32 32l288 0c17.7 0 32-14.3 32-32s-14.3-32-32-32L192 64zm0 160c-17.7 0-32 14.3-32 32s14.3 32 32 32l288 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-288 0zm0 160c-17.7 0-32 14.3-32 32s14.3 32 32 32l288 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-288 0zM16 232l0 48c0 13.3 10.7 24 24 24l48 0c13.3 0 24-10.7 24-24l0-48c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24zM40 368c-13.3 0-24 10.7-24 24l0 48c0 13.3 10.7 24 24 24l48 0c13.3 0 24-10.7 24-24l0-48c0-13.3-10.7-24-24-24l-48 0z',
+  },
+};
+
+type IconVariant = keyof typeof iconVariants;
+
+interface IconProps {
+  width?: number | string;
+  height?: number | string;
+  className?: string;
+  color?: string;
+  variant?: IconVariant;
+}
+
+export default function ListIcon({
+  width = 24,
+  height = 24,
+  className,
+  variant = 'solid',
+  color,
+}: IconProps) {
+  const selectedVariant = iconVariants[variant];
+
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      viewBox={selectedVariant.viewBox}
+      width={width}
+      height={height}
+      fill={color || 'currentColor'}
+      className={className}
+    >
+      <path d={selectedVariant.path} />
+    </svg>
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -6,6 +6,7 @@ import GitHubIcon from '../icons/brands/GitHubIcon';
 import LinkedInIcon from '../icons/brands/LinkedInIcon';
 import EnvelopeIcon from '../icons/glyphs/EnvelopeIcon';
 import FooterBackground from './_components/background/FooterBackground';
+import FooterScrollTop from './_components/FooterScrollButton';
 
 export default function FooterSection() {
   const anchorClassName = 'custom-hover-underline-swipe';
@@ -19,6 +20,7 @@ export default function FooterSection() {
         <FooterBackground />
       </div>
       <div className='bg-gradient-to-r from-[#000386] to-[#00478d] text-center md:text-left'>
+        <FooterScrollTop />
         <div
           className={`${divClassName} flex flex-col pt-8 pb-4 border-b-white border-b md:flex-row md:justify-between`}
         >

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -127,6 +127,7 @@ export default function HeaderSection() {
                 >
                   <HamburgerIcon color='currentColor' height={20} width={20} />
                 </button>
+                <ThemeSwitcher />
                 <CTAButton
                   as='button'
                   colorStyle='borderPurple'

--- a/src/components/layout/_components/FooterScrollButton.tsx
+++ b/src/components/layout/_components/FooterScrollButton.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import ChevronUpIcon from '@/components/icons/ui/ChevronUpIcon';
+
+export default function FooterScrollTop() {
+  return (
+    <div className='pb-12 pt-16'>
+      <div className='bg-gradient-to-r from-[#00024d] to-[#002141] flex justify-center py-4'>
+        <button
+          onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+          className='flex flex-col items-center leading-4 group'
+        >
+          <ChevronUpIcon
+            height={20}
+            width={20}
+            className='group-hover:-translate-y-1 transition-transform duration-150'
+          />
+          Jump to the Top
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/_components/ThemeSwitcher.tsx
+++ b/src/components/layout/_components/ThemeSwitcher.tsx
@@ -48,6 +48,8 @@ export default function ThemeSwitcher() {
 
   if (!mounted) return null;
 
+  const iconSize: number = 20;
+
   return (
     <div ref={ref} className='relative'>
       <button
@@ -58,9 +60,11 @@ export default function ThemeSwitcher() {
         aria-haspopup='true'
         className='flex items-center justify-center w-8 h-8 rounded-md opacity-70 hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--global-text-color))]  transition-colors duration-150 ease-linear'
       >
-        {theme === 'light' && <SunIcon />}
-        {theme === 'dark' && <MoonIcon />}
-        {theme === 'system' && <DesktopIcon />}
+        {theme === 'light' && <SunIcon height={iconSize} width={iconSize} />}
+        {theme === 'dark' && <MoonIcon height={iconSize} width={iconSize} />}
+        {theme === 'system' && (
+          <DesktopIcon height={iconSize} width={iconSize} />
+        )}
       </button>
       {open && (
         <div

--- a/src/components/mdx/AccessibilityMenu.tsx
+++ b/src/components/mdx/AccessibilityMenu.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { FontSize, useAccessibilityStore } from '@/store/useAccessibilityStore';
+import { useEffect, useState } from 'react';
+import { cn } from '@/lib/utilities';
+
+import UniversalAccessIcon from '../icons/glyphs/UniversalAccessIcon';
+
+export default function SlidingSettingsPanel() {
+  const { fontSize, setFontSize } = useAccessibilityStore();
+  const [mounted, setMounted] = useState(false);
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+  if (!mounted) return null;
+
+  return (
+    <>
+      <div
+        className={`fixed bottom-20 right-0 flex items-center transition-transform duration-300 ease-in-out z-50 ${
+          isOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          aria-label={
+            isOpen ? 'Close Accessibility Panel' : 'Open Accessibility Panel'
+          }
+          title={
+            isOpen ? 'Close Accessibility Panel' : 'Open Accessibility Panel'
+          }
+          className='fixed bottom-0 right-full z-40 p-3 rounded-l-md text-white hover:cursor-pointer hover:bg-[#0043fa] bg-[#4a77ff] dark:bg-[#00228a] border border-r-0 dark:border-blue-600 border-blue-700 hover:dark:bg-[#0043fa]'
+        >
+          <UniversalAccessIcon width={20} height={20} />
+        </button>
+
+        <div
+          className='bg-[#4a77ff] dark:bg-[#00228a] px-4 py-4 rounded-tl-md border border-r-0 dark:border-blue-600 border-blue-700'
+          role='region'
+          aria-label='Reading settings'
+        >
+          <div className='flex flex-col items-center gap-3 w-full text-white'>
+            <p className='text-sm font-bold uppercase text-center'>
+              Adjust Font Size
+            </p>
+            <div className='flex flex-col gap-1.5 w-full'>
+              {(['small', 'normal', 'large'] as FontSize[]).map((size) => {
+                const adjustedSizeName =
+                  size.charAt(0).toUpperCase() + size.slice(1);
+
+                return (
+                  <button
+                    key={size}
+                    onClick={() => setFontSize(size)}
+                    aria-label={`Set Content Font Size to ${adjustedSizeName}`}
+                    title={`Set Content Font Size to ${adjustedSizeName}`}
+                    className={cn(
+                      'w-full py-1.5 rounded text-xs text-center border transition-all duration-150',
+                      fontSize === size
+                        ? 'bg-[#308affa8] border-[#65a8ff]'
+                        : 'bg-[#549eff3f] border-[#003881]'
+                    )}
+                  >
+                    {adjustedSizeName}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {isOpen && (
+        <div
+          className='fixed inset-0 z-40'
+          onClick={() => setIsOpen(false)}
+          aria-hidden='true'
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/mdx/AccessibilityMenu.tsx
+++ b/src/components/mdx/AccessibilityMenu.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utilities';
 
 import UniversalAccessIcon from '../icons/glyphs/UniversalAccessIcon';
 
-export default function SlidingSettingsPanel() {
+export default function AccessibilityMenu() {
   const { fontSize, setFontSize } = useAccessibilityStore();
   const [mounted, setMounted] = useState(false);
 

--- a/src/components/mdx/MobileTableOfContent.tsx
+++ b/src/components/mdx/MobileTableOfContent.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { Heading } from '@/lib/mdx/mdx-utils';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { cn } from '@/lib/utilities';
 import { createPortal } from 'react-dom';
 
 import TableOfContent from './TableOfContent';
-import HamburgerIcon from '../icons/ui/HamburgerIcon';
 import CloseIcon from '../icons/ui/CloseIcon';
+import ListIcon from '../icons/ui/ListIcon';
 
 interface MobileTableOfContentProps {
   headings: Heading[];
@@ -32,26 +32,6 @@ export default function MobileTableOfContent({
     setTimeout(() => setIsOverlayVisible(false), 300);
   };
 
-  useEffect(() => {
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        setIsFloatingButtonVisible(!entry.isIntersecting);
-      },
-      { rootMargin: '0px 0px 100% 0px' }
-    );
-
-    const currentRef = initialTocRef.current;
-    if (currentRef) observer.observe(currentRef);
-    return () => {
-      if (currentRef) observer.unobserve(currentRef);
-    };
-  }, []);
-
-  const floatingButtonClassName = cn(
-    'fixed bottom-6 right-6 z-40 p-3 rounded-full opacity-0 scale-90 transition-all duration-300 pointer-events-none hover:text-white hover:cursor-pointer hover:bg-[#0043fa] bg-[#dfe7ff] dark:bg-[#00228a] shadow-sm shadow-black dark:shadow-white',
-    isFloatingButtonVisible && 'opacity-100 scale-100 pointer-events-auto'
-  );
-
   const overlayClassName = cn(
     'fixed inset-0 bg-black/75 z-[1000] backdrop-blur-sm opacity-0 transition-opacity duration-300 ease-out',
     isOverlayOpen && 'opacity-100'
@@ -64,17 +44,14 @@ export default function MobileTableOfContent({
 
   return (
     <>
-      <div ref={initialTocRef} className='w-full max-w-lg mx-auto'>
-        <TableOfContent headings={headings} variant='collapsible' />
-      </div>
-
       <button
         type='button'
-        className={floatingButtonClassName}
+        className='fixed bottom-6 right-0 z-40 p-3 rounded-l-md text-white hover:cursor-pointer hover:bg-[#0043fa] bg-[#4a77ff] dark:bg-[#00228a] border border-r-0 dark:border-blue-600 border-blue-700 hover:dark:bg-[#0043fa]'
         onClick={handleOpen}
         title='Open Table Of Contents'
+        aria-label='Open Table Of Contents'
       >
-        <HamburgerIcon width={20} height={20} />
+        <ListIcon width={20} height={20} />
       </button>
 
       {isOverlayVisible &&

--- a/src/components/mdx/MobileTableOfContent.tsx
+++ b/src/components/mdx/MobileTableOfContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Heading } from '@/lib/mdx/mdx-utils';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { cn } from '@/lib/utilities';
 import { createPortal } from 'react-dom';
 
@@ -16,11 +16,8 @@ interface MobileTableOfContentProps {
 export default function MobileTableOfContent({
   headings,
 }: MobileTableOfContentProps) {
-  const [isFloatingButtonVisible, setIsFloatingButtonVisible] =
-    useState<boolean>(false);
   const [isOverlayVisible, setIsOverlayVisible] = useState<boolean>(false);
   const [isOverlayOpen, setIsOverlayOpen] = useState<boolean>(false);
-  const initialTocRef = useRef<HTMLDivElement>(null);
 
   const handleOpen = () => {
     setIsOverlayVisible(true);

--- a/src/components/mdx/ReadingSurface.tsx
+++ b/src/components/mdx/ReadingSurface.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import {
+  fontSizeMap,
+  useAccessibilityStore,
+} from '@/store/useAccessibilityStore';
+import { useEffect, useState } from 'react';
+
+interface ReadingSurfaceProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function ReadingSurface({
+  children,
+  className,
+}: ReadingSurfaceProps) {
+  const fontSize = useAccessibilityStore((state) => state.fontSize);
+  const [mounted, setMounted] = useState<boolean>(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const activeFontSize = mounted
+    ? fontSizeMap[fontSize]
+    : fontSizeMap['normal'];
+
+  return (
+    <div
+      className={className}
+      style={{
+        fontSize: activeFontSize,
+        transition: 'font-size 0.2s ease',
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/mdx/ReadingSurface.tsx
+++ b/src/components/mdx/ReadingSurface.tsx
@@ -21,6 +21,7 @@ export default function ReadingSurface({
   useEffect(() => {
     setMounted(true);
   }, []);
+  if (!mounted) return null;
 
   const activeFontSize = mounted
     ? fontSizeMap[fontSize]

--- a/src/components/mdx/TableOfContent.tsx
+++ b/src/components/mdx/TableOfContent.tsx
@@ -50,14 +50,14 @@ export default function TableOfContent({
 
   const renderLinks = () => (
     <ol
-      className={`${listClassName} overflow-y-auto scrollbar-thumb-blue-900 scrollbar-thin dark:scrollbar-thumb-blue-500 dark:scrollbar-track-gray-900 scrollbar-track-gray-200`}
+      className={`${listClassName} overflow-y-auto scrollbar-thumb-blue-900 scrollbar-thin dark:scrollbar-thumb-blue-500 dark:scrollbar-track-gray-900 scrollbar-track-gray-200 `}
     >
       {headings.map((heading) => {
         const isActive = activeId === heading.slug;
 
         const linkClassName = cn('block py-1 px-3 text-sm underline-none');
         const listItemClassName = cn(
-          'border-l-2 border-[#ffffff1f] transition-all duration-75 ease-in-out hover:bg-[#549eff77] hover:border-[#0050b9]',
+          'border-l-2 border-[#2020201f] dark:border-[#ffffff1f] transition-all duration-75 ease-in-out hover:bg-[#549eff77] hover:border-[#0050b9]',
           heading.level === 3 && 'pl-4',
           isActive &&
             'bg-[#549eff3f] border-[#003881] hover:bg-[#549eff77] hover:border-[#0050b9]'

--- a/src/store/useAccessibilityStore.tsx
+++ b/src/store/useAccessibilityStore.tsx
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type FontSize = 'small' | 'normal' | 'large';
+
+export const fontSizeMap = {
+  small: '14px',
+  normal: '16px',
+  large: '18px',
+};
+
+interface SettingsState {
+  fontSize: FontSize;
+  setFontSize: (size: FontSize) => void;
+}
+
+export const useAccessibilityStore = create<SettingsState>()(
+  persist(
+    (set) => ({
+      fontSize: 'normal',
+      setFontSize: (size) => set({ fontSize: size }),
+    }),
+    {
+      name: 'user-font-settings',
+    }
+  )
+);


### PR DESCRIPTION
# Patch 2.5.1 - Accessibility Menu
This patch adds an Accessibility menu to the website and a “Jump to Top” button into the Footer.

<hr />

## New Zustand Store
- create `useAccessibilityStore` for font size settings and future accessibility settings

## New Icons
- create AccessibilityIcon.tsx
- create ListIcon.tsx

## Layout Components
- create `FooterScrollButton` component to allow users to scroll to the top once reaching the footer
- add `FooterScrollButton` to global Footer
- adjust icon sizes of `ThemeSwitcher` icons
- add `ThemeSwitcher` to mobile version of Header.tsx

## MDX Components
- create `ReadingSurface` wrapper to allow dynamic adjustment of article/case study font size
- adjust styling to both `TableOfContent` and `MobileTableOfContent`
- change layout of `MobileTableOfContent`
- create `AccessibilityMenu` to dynamically adjust the font size of MDX content and for future accessibility settings

## Page Layouts
- add `AccessibilityMenu` to `/articles` and `/case-studies` `/[slug]` page.tsx
- add `ReadingSurface` to `/articles` and `/case-studies` `/[slug]` page.tsx